### PR TITLE
Rabbitmq test staging

### DIFF
--- a/mpc_webhooks/models/utils.py
+++ b/mpc_webhooks/models/utils.py
@@ -47,6 +47,9 @@ def publish_change(id,model,trigger,dbname=None):
 
 
 def send_webhook(id, model, trigger, dbname=None):
+
+    publish_change(id,model,trigger,dbname=dbname)
+
     try:
         env_type = None
         webhook_url = None

--- a/mpc_webhooks/models/utils.py
+++ b/mpc_webhooks/models/utils.py
@@ -2,6 +2,7 @@ from odoo import fields, models, api
 import logging
 import json
 import pika
+import os
 import requests
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
@@ -20,10 +21,7 @@ def publish_change(id,model,trigger,dbname=None):
     try:
         env_type = None
         exchange = ""
-        if "staging" in dbname:
-            env_type = "staging"
-        else:
-            env_type = "production"
+        env_type = os.environ['ODOO_STAGE']
 
         topic_name = "odoo_{model}_{env}".format(model=model,env=env_type)
         _logger.info("topic={topic}".format(topic=topic_name))

--- a/mpc_webhooks/models/utils.py
+++ b/mpc_webhooks/models/utils.py
@@ -17,7 +17,7 @@ def _post(url, payload):
         _logger.info("Webhook Timeout[{0}]".format(url))
 
 
-def publish_change(id,model,trigger,dbname=None):
+def publish_change(self,id,model,trigger,dbname=None):
     try:
         env_type = None
         exchange = ""
@@ -30,8 +30,11 @@ def publish_change(id,model,trigger,dbname=None):
             'trigger': trigger
         }
 
+        config_env = self.env["ir.config_parameter"].sudo()
+        rabbit_url = config_env.get_param("rabbit_mq_broker", "").strip()
+
         _logger.info("connecting to rabbit")
-        params = pika.URLParameters('amqp://uaoqejpl:vrjdmxg7QDzqcPyS7qAIW5HSme4OEa1s@skunk.rmq.cloudamqp.com/uaoqejpl')
+        params = pika.URLParameters(rabbit_url)
         conn = pika.BlockingConnection(params)
         channel = conn.channel()
         channel.exchange_declare(exchange=topic_name,exchange_type="fanout",durable=True,auto_delete=False)

--- a/mpc_webhooks/models/utils.py
+++ b/mpc_webhooks/models/utils.py
@@ -17,7 +17,7 @@ def _post(url, payload):
         _logger.info("Webhook Timeout[{0}]".format(url))
 
 
-def publish_change(self,id,model,trigger,dbname=None):
+def publish_change(id,model,trigger,dbname=None):
     try:
         env_type = None
         exchange = ""
@@ -30,11 +30,8 @@ def publish_change(self,id,model,trigger,dbname=None):
             'trigger': trigger
         }
 
-        config_env = self.env["ir.config_parameter"].sudo()
-        rabbit_url = config_env.get_param("rabbit_mq_broker", "").strip()
-
         _logger.info("connecting to rabbit")
-        params = pika.URLParameters(rabbit_url)
+        params = pika.URLParameters('amqp://uaoqejpl:vrjdmxg7QDzqcPyS7qAIW5HSme4OEa1s@skunk.rmq.cloudamqp.com/uaoqejpl')
         conn = pika.BlockingConnection(params)
         channel = conn.channel()
         channel.exchange_declare(exchange=topic_name,exchange_type="fanout",durable=True,auto_delete=False)

--- a/mpc_webhooks/models/utils.py
+++ b/mpc_webhooks/models/utils.py
@@ -36,7 +36,7 @@ def publish_change(id,model,trigger,dbname=None):
         params = pika.URLParameters('amqp://uaoqejpl:vrjdmxg7QDzqcPyS7qAIW5HSme4OEa1s@skunk.rmq.cloudamqp.com/uaoqejpl')
         conn = pika.BlockingConnection(params)
         channel = conn.channel()
-        channel.exchange_declare(exchange=topic_name,type="fanout",durable=True,auto_delete=False)
+        channel.exchange_declare(exchange=topic_name,exchange_type="fanout",durable=True,auto_delete=False)
         channel.basic_publish(body=json.dumps(payload),exchange=topic_name,routing_key="")
         _logger.info("message sent")
 

--- a/mpc_webhooks/models/utils.py
+++ b/mpc_webhooks/models/utils.py
@@ -1,7 +1,7 @@
 from odoo import fields, models, api
 import logging
 import json
-
+import pika
 import requests
 from concurrent.futures import ThreadPoolExecutor, as_completed
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 futures
 pyjwt==1.7.1
 requests
+pika


### PR DESCRIPTION
This PR adds a rabbitmq publisher as an alternative to the webhook solution currently in use. Each model change is published in a durable fanout exchange with a name like:

odoo_{model name}_{env} ie. odoo_res.partner_staging

The goal is to allow more apps to subscribe to Odoo model changes and build their own caches if necessary without overwhelming the webhook app.